### PR TITLE
Add restore keys to Bazel cache step

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -6,5 +6,8 @@ build --show_timestamps
 build --announce_rc
 build --color=yes
 build --disk_cache='~/.cache/bazel/'
+build --show_task_finish
+build --terminal_columns=120
 
 test --test_output=all
+test --test_verbose_timeout_warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,9 @@ jobs:
       with:
         path: |
           ~/.cache/bazel
-        key: ${{ matrix.os }}-bazel-${{ env.BAZEL_VERSION }}-${{ matrix.compiler }}
+        key: ${{ matrix.os }}-bazel-${{ env.BAZEL_VERSION }}-${{ matrix.compiler }}-${{ github.sha }}
+        restore-keys: |
+          ${{ matrix.os }}-bazel-${{ env.BAZEL_VERSION }}-${{ matrix.compiler }}-
 
     - name: Setup Bazel
       if: matrix.build_tool == 'bazel'
@@ -168,7 +170,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ matrix.os }}-bazel-${{ env.BAZEL_VERSION }}-${{ matrix.compiler }}
+          key: ${{ matrix.os }}-bazel-${{ env.BAZEL_VERSION }}-${{ matrix.compiler }}-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.os }}-bazel-${{ env.BAZEL_VERSION }}-${{ matrix.compiler }}-
 
       - name: Setup Bazel
         run: |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ but allow transfer between states (e.g. moving a buffer from a 'read' state to a
 Check out the [examples](./examples).
 
 In order to build the examples, you'll need a compiler supporting C++14 and
-[CMake](https://cmake.org/).
+[CMake](https://cmake.org/) or [Bazel](https://bazel.build/).
 
 [Google Test](https://github.com/google/googletest) is required to run the
 tests and is included as a submodule. Make sure to initialize it after cloning


### PR DESCRIPTION
Update Bazel cache key to use the commit hash in order to cache Bazel
action outputs on every commit. This commit also adds restore key to the
Bazel cache step to allow use caches with action outputs from previous
commits.